### PR TITLE
Fix lxml dependency check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ long_description = read('README.rst')
 
 setup(
     name='nsxramlclient',
-    version='2.0.7',
+    version='2.0.8',
     packages=['nsxramlclient'],
     url='http://github.com/vmware/nsxramlclient',
     license='MIT',
@@ -29,5 +29,5 @@ setup(
     'Topic :: Software Development :: Libraries',
     'License :: OSI Approved :: MIT License',
     'Programming Language :: Python :: 2.7'],
-    install_requires=['pyopenssl', 'pyraml-parser>=0.1.3', 'lxml<=3.6.0', 'requests>=2.7.0']
+    install_requires=['pyopenssl', 'pyraml-parser>=0.1.3', 'lxml<=4.3.3', 'requests>=2.7.0']
 )


### PR DESCRIPTION
 As lxml <= 3.6 fails to compile on new macOS versions