### PR TITLE
TPR: Update deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ long_description = read('README.rst')
 
 setup(
     name='nsxramlclient',
-    version='2.0.8',
+    version='2.0.9',
     packages=['nsxramlclient'],
     url='http://github.com/vmware/nsxramlclient',
     license='MIT',
@@ -29,5 +29,5 @@ setup(
     'Topic :: Software Development :: Libraries',
     'License :: OSI Approved :: MIT License',
     'Programming Language :: Python :: 2.7'],
-    install_requires=['pyopenssl', 'pyraml-parser>=0.1.3', 'lxml<=4.3.3', 'requests>=2.7.0']
+    install_requires=['pyopenssl', 'pyraml-parser>=0.1.3', 'lxml<=4.4.1', 'requests>=2.7.0']
 )


### PR DESCRIPTION
Running pass-bootstrap prerquisites script generates red,flasing, eye-hurting, and panda saddening warning:

```
nsxramlclient 2.0.8 has requirement lxml<=4.3.3, but you'll have lxml 4.4.1 which is incompatible.
```
This PR updates lxml to v 4.4.1 to get rid of it. 
